### PR TITLE
update name of dixie.edu

### DIFF
--- a/universities.csv
+++ b/universities.csv
@@ -1483,7 +1483,7 @@ Dirección General de Institutos Tecnológicos,http://www.dgit.gob.mx/,Mexico,MX
 Divine Word College,http://www.svd.org,United States,US,University
 Divine Word College of Legazpi,http://www.dwc-legazpi.edu/,Philippines,PH,University
 Divine Word University,http://www.dwu.ac.pg/,Papua New Guinea,PG,University
-Dixie College,http://www.dixie.edu/,United States,US,University
+Dixie State University,http://www.dixie.edu/,United States,US,University
 Diyala University,http://www.uodiyala.edu.iq/,Iraq,IQ,University
 Dneprodzerzhinsk State Technical University,http://www.dstu.dp.ua/,Ukraine,UA,University
 Dnepropetrovsk National University,http://www.dnu.dp.ua/,Ukraine,UA,University


### PR DESCRIPTION
Dixie College was officially renamed Dixie State University a few years ago. The domain name is unchanged.
